### PR TITLE
Add workflow_dispatch to triggers

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -8,6 +8,8 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
+
 env:
   CODE_LOCATION: src/
 jobs:


### PR DESCRIPTION
So that I can run builds manually, e.g. after I bump a version tag.