### PR TITLE
Simplify release matching, using only Semver

### DIFF
--- a/src/TFWhatsUp.Console/Program.cs
+++ b/src/TFWhatsUp.Console/Program.cs
@@ -27,9 +27,8 @@ public static class Extensions
         return SemVersion.Parse(versionNumber, SemVersionStyles.Any);
     }
 }
-public record ReleaseInfo(string OrgName, string RepoName, SemVersion Version, DateTimeOffset CreatedOn);
 
-public record ReleaseInfoWithBody(ReleaseInfo ReleaseInfo, string Body);
+public record ReleaseInfoWithBody(SemVersion Version, string Body);
 public static class ExitCodes
 {
     public const int UNKNOWN_ERROR = 1;
@@ -193,7 +192,7 @@ internal sealed class WhatsUpCommand : AsyncCommand<WhatsUpCommand.Settings>
         {
             var highlightedBody = ProcessBodyForHighlights(release.Body, totalTypes, settings);
 
-            latestReleasesTable.AddRow(release.ReleaseInfo.Version.ToString(), highlightedBody);
+            latestReleasesTable.AddRow(release.Version.ToString(), highlightedBody);
         }
 
         return latestReleasesTable;
@@ -234,13 +233,7 @@ internal sealed class WhatsUpCommand : AsyncCommand<WhatsUpCommand.Settings>
             .Where(x => x.TagName.IsSemanticallyGreaterThan(versionNumber))
             .OrderBy(x => x.TagName.ToSemVer(), SemVersion.SortOrderComparer)
             .Select(x =>
-                new ReleaseInfoWithBody(
-                    new ReleaseInfo(
-                        githubOrg,
-                        gitHubRepo,
-                        x.TagName.ToSemVer(),
-                        x.CreatedAt)
-                    , x.Body));
+                new ReleaseInfoWithBody(x.TagName.ToSemVer(), x.Body));
 
         return greaterSemverReleases.ToList();
     }

--- a/src/TFWhatsUp.Console/Program.cs
+++ b/src/TFWhatsUp.Console/Program.cs
@@ -113,7 +113,7 @@ internal sealed class WhatsUpCommand : AsyncCommand<WhatsUpCommand.Settings>
         {
             var allReleases = await apiClient.Repository.Release.GetAll(provider.GitHubOrg, provider.GitHubRepo);
 
-            var applicableReleases = GetApplicableReleases(provider.GitHubOrg, provider.GitHubRepo, provider.Version, allReleases);
+            var applicableReleases = GetApplicableReleases(provider.Version, allReleases);
 
             if (applicableReleases.Any())
             {
@@ -225,7 +225,7 @@ internal sealed class WhatsUpCommand : AsyncCommand<WhatsUpCommand.Settings>
         return notesResult.ToString();
     }
 
-    private List<ReleaseInfoWithBody> GetApplicableReleases(string githubOrg, string gitHubRepo, string versionNumber, IReadOnlyList<Release> allReleases)
+    private List<ReleaseInfoWithBody> GetApplicableReleases(string versionNumber, IReadOnlyList<Release> allReleases)
     {
         // TODO: Move to TryParse here rather than assuming they'll be parseable. If they're not, show a warning.
         // TODO: Parse semver earlier so we're not repeating ourselves as much

--- a/src/TFWhatsUp.Console/Program.cs
+++ b/src/TFWhatsUp.Console/Program.cs
@@ -245,32 +245,6 @@ internal sealed class WhatsUpCommand : AsyncCommand<WhatsUpCommand.Settings>
         return greaterSemverReleases.ToList();
     }
 
-    private async Task<ReleaseInfo?> GetMatchingGitHubRelease(GitHubClient apiClient, string providerGitHubOrg, string providerGitHubRepo, string providerVersion)
-    {
-        // TODO: Fail gracefully if API client has an error
-        Release? matchingRelease;
-        try
-        {
-            matchingRelease = await apiClient.Repository.Release.Get(providerGitHubOrg, providerGitHubRepo, $"v{providerVersion}");
-        }
-        catch (ApiException ex)
-        {
-            AnsiConsole.WriteException(ex);
-            return null;
-        }
-        if (matchingRelease is null) { return null; }
-
-        var releaseDate = matchingRelease.CreatedAt;
-        var releaseSemver = SemVersion.Parse(matchingRelease.TagName, SemVersionStyles.Any);
-        if (releaseSemver is null)
-        {
-            WriteWarning($"Could not determine Semantic Version for provider '{providerGitHubOrg}/{providerVersion}' release '{providerVersion}'");
-            return null;
-        }
-
-        return new ReleaseInfo(providerGitHubOrg, providerGitHubRepo, releaseSemver, releaseDate);
-    }
-
     private GitHubClient CreateOctokitApiClient(string token)
     {
         var client = new GitHubClient(new ProductHeaderValue("TFWhatsUp"));


### PR DESCRIPTION
Previously we got a matching GitHub release first, but that assumed there was going to definitely be one. We hit several cases where those releases weren't available, but semantically greater versions were, which would still be applicable for the tool.

This PR:

* Stops matching a specific release
* Removes date-matching from the release, and focuses solely on the semantic versions of releases that could be applicable.

Resolves #32 -- now finds later releases that might have release notes. Later releases that don't have release notes are out of the scope of this tool.

Resolves #33 -- if a provider version doesn't exist, it'll still find all those releases that are semantically later.

Resolves #34 -- if a provider version doesn't exist, it'll still find all those releases that are semantically later.